### PR TITLE
Фикс отображения эмоутов

### DIFF
--- a/interface/skin.dmf
+++ b/interface/skin.dmf
@@ -109,12 +109,12 @@ window "mapwindow"
 		size = 640x480
 		anchor1 = 0,0
 		anchor2 = 100,100
-		font-family = "Grand9K Pixel"
-		font-size = 6
+		font-family = "Arial"
+		font-size = 7
 		is-default = true
 		right-click = true
 		saved-params = "zoom;letterbox;zoom-mode"
-		style = "img.icon { width: auto; height: auto } .center { text-align: center; } .maptext { font-family: 'Grand9K Pixel'; font-size: 6pt; -dm-text-outline: 1px black; color: white; line-height: 1.0; } .command_headset { font-weight: bold; } .context { font-family: 'Pixellari'; font-size: 12pt; -dm-text-outline: 1px black; }  .subcontext { font-family: 'TinyUnicode'; font-size: 12pt; line-height: 0.75; } .small { font-family: 'Spess Font'; font-size: 6pt; line-height: 1.4; } .big { font-family: 'Pixellari'; font-size: 12pt; } .reallybig { font-size: 12pt; } .extremelybig { font-size: 12pt; } .greentext { color: #00FF00; font-size: 6pt; } .redtext { color: #FF0000; font-size: 6pt; } .clown { color: #FF69BF; font-weight: bold; } .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; } .italics { font-family: 'Spess Font'; font-size: 6pt; line-height: 1.4; }"
+        style = "img.icon { width: auto; height: auto } .center { text-align: center; } .maptext { font-family: 'Small Fonts'; font-size: 7px; -dm-text-outline: 1px black; color: white; line-height: 1.1; } .command_headset { font-weight: bold;\tfont-size: 8px; } .context { font-family: 'Small Fonts'; font-size: 8px; -dm-text-outline: 1px black; }  .subcontext { font-family: 'Small Fonts'; font-size: 6px; line-height: 0.75; } .small { font-size: 6px; } .big { font-size: 8px; } .reallybig { font-size: 8px; } .extremelybig { font-size: 8px; } .greentext { color: #00FF00; font-size: 7px; } .redtext { color: #FF0000; font-size: 7px; } .clown { color: #FF69Bf; font-size: 7px;  font-weight: bold; } .his_grace { color: #15D512; } .hypnophrase { color: #0d0d0d; font-weight: bold; } .yell { font-weight: bold; } .italics { font-size: 6px; }"
     elem "status_bar"
 		type = LABEL
 		pos = 0,470


### PR DESCRIPTION
## About The Pull Request

  Фиксит отображение эмоутов на кириллице.
  Отображение можно сделать лучше, но визуал это не моё. Поэтому здесь просто фикс...
 
## Proof of Testing

<summary>Screenshots/Videos</summary>
  
<img width="273" height="206" alt="изображение" src="https://github.com/user-attachments/assets/45899bae-13c0-444a-ba93-cb74432c2710" />



## Changelog

:cl: mogeoko
fix: Пофикшено отображение эмоутов
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
